### PR TITLE
Patched Thor and Nokogiri July 2025 CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # rspec failure tracking
 .rspec_status
+acts_as_trackable-*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gemspec
 gem 'activerecord', '~> 7.2', '>= 7.2.2'
 gem 'activesupport', '~> 7.2', '>= 7.2.2'
-gem 'nokogiri', '~> 1.16', '>= 1.16.7'
-gem 'rake', '~> 13.2', '>= 13.2.1'
 
 group :test do
   gem 'sqlite3', '~> 2.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    acts_as_trackable (0.3.5)
+    acts_as_trackable (0.4.1)
 
 GEM
   remote: https://rubygems.org/
@@ -66,9 +66,9 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     minitest (5.25.5)
-    nokogiri (1.18.8-arm64-darwin)
+    nokogiri (1.18.9-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.8-x86_64-darwin)
+    nokogiri (1.18.9-x86_64-darwin)
       racc (~> 1.4)
     pp (0.6.2)
       prettyprint
@@ -109,7 +109,7 @@ GEM
     sqlite3 (2.6.0-arm64-darwin)
     sqlite3 (2.6.0-x86_64-darwin)
     stringio (3.1.5)
-    thor (1.3.2)
+    thor (1.4.0)
     timeout (0.4.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -125,8 +125,6 @@ DEPENDENCIES
   activesupport (~> 7.2, >= 7.2.2)
   acts_as_trackable!
   generator_spec
-  nokogiri (~> 1.16, >= 1.16.7)
-  rake (~> 13.2, >= 13.2.1)
   sqlite3 (~> 2.2)
 
 BUNDLED WITH

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # acts_as_trackable Changelog
 ## Version: 0.4.0
+  ### Patch
+    - Upgraded dependencies to patch CVE-2025-6021, CVE-2025-6170, CVE-2025-49794, CVE-2025-49795, CVE-2025-49796, and CVE-2025-54314.
+## Version: 0.4.0
   ### Minor
     - Performance Improvement: The `object_activity` method now memoizes results.
     - Migration Required: Replace `Preloader` calls with `includes(:object_activity)` for bulk loading.

--- a/lib/acts_as_trackable/version.rb
+++ b/lib/acts_as_trackable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTrackable
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.4.1'.freeze
 end


### PR DESCRIPTION
Upgraded dependencies to patch 

- CVE-2025-6021[https://nvd.nist.gov/vuln/detail/CVE-2025-6021]
- CVE-2025-6170[https://nvd.nist.gov/vuln/detail/CVE-2025-6170]
- CVE-2025-49794[https://nvd.nist.gov/vuln/detail/CVE-2025-49794]
- CVE-2025-49795[https://nvd.nist.gov/vuln/detail/CVE-2025-49795]
- CVE-2025-49796[https://nvd.nist.gov/vuln/detail/CVE-2025-49796]
- CVE-2025-54314[https://nvd.nist.gov/vuln/detail/CVE-2025-54314]