### PR TITLE
Update active_support to 7.2.3.1 to patch several CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,18 +1,18 @@
 PATH
   remote: .
   specs:
-    acts_as_trackable (0.4.8)
+    acts_as_trackable (0.4.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.2.3)
-      activesupport (= 7.2.3)
-    activerecord (7.2.3)
-      activemodel (= 7.2.3)
-      activesupport (= 7.2.3)
+    activemodel (7.2.3.1)
+      activesupport (= 7.2.3.1)
+    activerecord (7.2.3.1)
+      activemodel (= 7.2.3.1)
+      activesupport (= 7.2.3.1)
       timeout (>= 0.4.0)
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -21,7 +21,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     base64 (0.3.0)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,10 @@
 # acts_as_trackable Changelog
+## Version: 0.4.9
+  ### Patch
+  #### Resolves several CVEs related to ActiveSupport by updating to 7.2.3.1:
+      - CVE-2026-33176
+      - CVE-2026-33169
+      - CVE-2026-33170
 ## Version: 0.4.8
   ### Patch
     - Removed unused `generator_spec` development dependency, eliminating unnecessary transitive dependencies (railties, actionpack, nokogiri, rack, loofah, etc.).

--- a/lib/acts_as_trackable/version.rb
+++ b/lib/acts_as_trackable/version.rb
@@ -1,3 +1,3 @@
 module ActsAsTrackable
-  VERSION = '0.4.8'.freeze
+  VERSION = '0.4.9'.freeze
 end


### PR DESCRIPTION
## Resolves several CVEs related to ActiveSupport by updating to 7.2.3.1:
      - CVE-2026-33176
      - CVE-2026-33169
      - CVE-2026-33170